### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -393,7 +393,7 @@ func (app *App) SetTrustXHeaders(t bool) {
 	app.trustXHeaders = t
 }
 
-// AppendSlash returns if the app will automatically append
+// AppendsSlash returns if the app will automatically append
 // a slash when appropriate. See SetAppendSlash for a more
 // detailed description.
 func (app *App) AppendsSlash() bool {

--- a/blobstore/range.go
+++ b/blobstore/range.go
@@ -24,7 +24,7 @@ func (r *Range) IsValid() bool {
 	return !r.empty()
 }
 
-// Range() returns the Range's Start and End, which
+// Range returns the Range's Start and End, which
 // might be nil.
 func (r *Range) Range() (*int64, *int64) {
 	return r.Start, r.End

--- a/cache/typer.go
+++ b/cache/typer.go
@@ -18,7 +18,7 @@ func (t *uniTyper) Type(_ string) reflect.Type {
 	return t.typ
 }
 
-// UniType returns a Typer which returns the type of
+// UniTyper returns a Typer which returns the type of
 // obj for all the keys.
 func UniTyper(obj interface{}) Typer {
 	return &uniTyper{typ: reflect.TypeOf(obj)}

--- a/log/log.go
+++ b/log/log.go
@@ -348,7 +348,7 @@ func (l *Logger) IsDebug() bool {
 	return l.level <= LDebug
 }
 
-// AddWriter adds a writer to the standard logger for the standard logger.
+// SetOutput adds a writer to the standard logger for the standard logger.
 func SetOutput(out Writer) {
 	Std.AddWriter(out)
 }

--- a/net/oauth2/client.go
+++ b/net/oauth2/client.go
@@ -182,7 +182,7 @@ func (c *Client) Get(u string, form url.Values, accessToken string) (*httpclient
 	return c.do(c.client().GetForm, u, form, accessToken)
 }
 
-// Get sends an oAuth 2 POST request.
+// Post gets sends an oAuth 2 POST request.
 func (c *Client) Post(u string, form url.Values, accessToken string) (*httpclient.Response, error) {
 	return c.do(c.client().PostForm, u, form, accessToken)
 }

--- a/util/fileutil/fileutil.go
+++ b/util/fileutil/fileutil.go
@@ -47,7 +47,7 @@ func FileExists(filename string) bool {
 	return ex && !isDir
 }
 
-// FileExists returns true iff a directory exists
+// DirExists returns true iff a directory exists
 // at the given path.
 func DirExists(filename string) bool {
 	ex, isDir := Exists(filename)

--- a/util/formatutil/size.go
+++ b/util/formatutil/size.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// FormatSize returns the given size in bytes formatted as a
+// Size returns the given size in bytes formatted as a
 // human readable string. The precision and unit will vary
 // depending on the size.
 func Size(s uint64) string {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._
